### PR TITLE
169749221 remove extra spaces in sentences

### DIFF
--- a/api/test/api/end_to_end_test.clj
+++ b/api/test/api/end_to_end_test.clj
@@ -5,7 +5,8 @@
             [clojure.test :refer [deftest is use-fixtures]]
             [data.entities.document-plan :as dp]
             [data.entities.data-files :as data-files]
-            [data.entities.dictionary :as dictionary]))
+            [data.entities.dictionary :as dictionary]
+            [clojure.tools.logging :as log]))
 
 (defn valid-sentence?
   "Test validity of the sentence.
@@ -59,10 +60,8 @@
   (when (some? result-id)
     (wait-for-results result-id)
     (let [response (q (str "/nlg/" result-id) :get nil)]
-      (->> (get-in response [:body :variants 0 :children 0 :children 0 :children])
-           (map :text)
-           (string/join " ")
-           (string/trim)))))
+      (nlp/rebuild-sentence
+       (get-in response [:body :variants 0 :children 0 :children 0 :children])))))
 
 (deftest ^:integration single-element-plan-generation
   (let [data-file-id (data-files/store!

--- a/api/test/api/end_to_end_test.clj
+++ b/api/test/api/end_to_end_test.clj
@@ -135,7 +135,7 @@
                           :dataId           data-file-id})]
     (is (= 200 status))
     (is (some? result-id))
-    (is (= "Good ." (get-first-variant result-id)))))
+    (is (= "Good." (get-first-variant result-id)))))
 
 (deftest ^:integration complex-amr-plan-generation
   (let [data-file-id (data-files/store!

--- a/api/test/api/end_to_end_test.clj
+++ b/api/test/api/end_to_end_test.clj
@@ -98,7 +98,7 @@
                           :dataId           data-file-id})]
     (is (= 200 status))
     (is (some? result-id))
-    (is (contains? #{"Building Search Applications ." "Good Building Search Applications ."}
+    (is (contains? #{"Building Search Applications." "Good Building Search Applications."}
                    (get-first-variant result-id)))))
 
 (deftest ^:integration author-amr-plan-generation
@@ -123,7 +123,7 @@
                           :dataId           data-file-id})]
     (is (= 200 status))
     (is (some? result-id))
-    (is (= "This is a very good book : Building Search Applications ." (get-first-variant result-id)))))
+    (is (= "This is a very good book: Building Search Applications." (get-first-variant result-id)))))
 
 
 (deftest ^:integration single-modifier-plan-generation
@@ -148,4 +148,4 @@
                           :dataId           data-file-id})]
     (is (= 200 status))
     (is (some? result-id))
-    (is (= "Carol cut envelope to into pieces with knife ." (get-first-variant result-id)))))
+    (is (= "Carol cut envelope to into pieces with knife." (get-first-variant result-id)))))

--- a/api/test/api/end_to_end_test.clj
+++ b/api/test/api/end_to_end_test.clj
@@ -1,12 +1,10 @@
 (ns api.end-to-end-test
   (:require [api.db-fixtures :as fixtures]
             [api.test-utils :refer [q load-test-document-plan rebuild-sentence]]
-            [clojure.string :as string]
             [clojure.test :refer [deftest is use-fixtures]]
             [data.entities.document-plan :as dp]
             [data.entities.data-files :as data-files]
-            [data.entities.dictionary :as dictionary]
-            [clojure.tools.logging :as log]))
+            [data.entities.dictionary :as dictionary]))
 
 (defn valid-sentence?
   "Test validity of the sentence.

--- a/api/test/api/end_to_end_test.clj
+++ b/api/test/api/end_to_end_test.clj
@@ -1,6 +1,6 @@
 (ns api.end-to-end-test
   (:require [api.db-fixtures :as fixtures]
-            [api.test-utils :refer [q load-test-document-plan]]
+            [api.test-utils :refer [q load-test-document-plan rebuild-sentence]]
             [clojure.string :as string]
             [clojure.test :refer [deftest is use-fixtures]]
             [data.entities.document-plan :as dp]
@@ -60,7 +60,7 @@
   (when (some? result-id)
     (wait-for-results result-id)
     (let [response (q (str "/nlg/" result-id) :get nil)]
-      (nlp/rebuild-sentence
+      (rebuild-sentence
        (get-in response [:body :variants 0 :children 0 :children 0 :children])))))
 
 (deftest ^:integration single-element-plan-generation

--- a/api/test/api/test_utils.clj
+++ b/api/test/api/test_utils.clj
@@ -37,9 +37,10 @@
     (edn/read (PushbackReader. r))))
 
 (defn rebuild-sentence [tokens]
-  (->> (map (fn [{type :type text :text}]
-                (case (keyword type)
-                  :WORD (str " " text)
-                  :PUNCTUATION text)) tokens)
+  (->> tokens
+       (map (fn [{type :type text :text}]
+          (case (keyword type)
+            :WORD (str " " text)
+            :PUNCTUATION text)))
        (apply str)
        (string/trim)))

--- a/api/test/api/test_utils.clj
+++ b/api/test/api/test_utils.clj
@@ -3,6 +3,7 @@
             [api.utils :as utils]
             [clojure.edn :as edn]
             [clojure.java.io :as io]
+            [clojure.string :as string]
             [jsonista.core :as json])
   (:import (java.io PushbackReader)
            (org.httpkit BytesInputStream)))
@@ -36,8 +37,9 @@
     (edn/read (PushbackReader. r))))
 
 (defn rebuild-sentence [tokens]
-  (apply str
-         (map (fn [{type :type text :text}]
-                (case type
-                  :WORD (str text " ")
-                  :PUNCTUATION text)) tokens)))
+  (->> (map (fn [{type :type text :text}]
+                (case (keyword type)
+                  :WORD (str " " text)
+                  :PUNCTUATION text)) tokens)
+       (apply str)
+       (string/trim)))

--- a/api/test/api/test_utils.clj
+++ b/api/test/api/test_utils.clj
@@ -34,3 +34,10 @@
 (defn load-test-document-plan [filename]
   (with-open [r (io/reader (format "test/resources/document_plans/%s.edn" filename))]
     (edn/read (PushbackReader. r))))
+
+(defn rebuild-sentence [tokens]
+  (apply str
+         (map (fn [{type :type text :text}]
+                (case type
+                  :WORD (str text " ")
+                  :PUNCTUATION text)) tokens)))

--- a/core/src/acc_text/nlg/utils/nlp.clj
+++ b/core/src/acc_text/nlg/utils/nlp.clj
@@ -23,10 +23,3 @@
     (wrap-sentence
      (capitalize-first-word s))
     ""))
-
-(defn rebuild-sentence [tokens]
-  (apply str
-         (map (fn [{type :type text :text}]
-                (case type
-                  :WORD (str text " ")
-                  :PUNCTUATION text)) tokens)))

--- a/core/src/acc_text/nlg/utils/nlp.clj
+++ b/core/src/acc_text/nlg/utils/nlp.clj
@@ -23,3 +23,10 @@
     (wrap-sentence
      (capitalize-first-word s))
     ""))
+
+(defn rebuild-sentence [tokens]
+  (apply str
+         (map (fn [{type :type text :text}]
+                (case type
+                  :WORD (str text " ")
+                  :PUNCTUATION text)) tokens)))

--- a/core/src/acc_text/nlg/utils/nlp.clj
+++ b/core/src/acc_text/nlg/utils/nlp.clj
@@ -12,6 +12,14 @@
 
 (defn token-type [token] (if (word? token) "WORD" "PUNCTUATION"))
 
+(defn capitalize-first-word [[head & tail]]
+  (str/join [(str/capitalize head) (apply str tail)]))
+
+(defn wrap-sentence [s]
+  (str (str/trim s) "."))
+
 (defn process-sentence [s]
-  (reduce str (when-not (str/blank? s)
-                (str/join [(str/capitalize (first s)) (apply str (rest s)) \.]))))
+  (if-not (str/blank? s)
+    (wrap-sentence
+     (capitalize-first-word s))
+    ""))


### PR DESCRIPTION
This bug is mostly in representation. UI has a weird way of reading result. For now leave UI as it is, in tests side - fake a correct sentence