### PR TITLE
Pass GF error to response

### DIFF
--- a/core/gf/server.py
+++ b/core/gf/server.py
@@ -143,7 +143,7 @@ def application(environ, start_response, data):
         return {"error": error.message}
     except Exception as ex:
         logger.exception(ex)
-        return {"error": str(ex)}
+        return {"error": str(ex).strip()}
 
 
 

--- a/core/src/acc_text/nlg/gf/generator.clj
+++ b/core/src/acc_text/nlg/gf/generator.clj
@@ -4,7 +4,8 @@
             [acc-text.nlg.utils :as utils]
             [clojure.spec.alpha :as s]
             [clojure.string :as str]
-            [jsonista.core :as json]))
+            [jsonista.core :as json]
+            [clojure.tools.logging :as log]))
 
 (defn join-body [& args]
   (->> args
@@ -154,18 +155,20 @@
           module
           instance))
 
+(defn grammar->content [{::grammar/keys [module instance] :as grammar}]
+  {(str module)                (->abstract grammar)
+   (str module "Body")         (->incomplete grammar)
+   (str module "Lex")          (->interface grammar)
+   (str module "Lex" instance) (->resource grammar)
+   (str module instance)       (->concrete grammar)})
+
 (defn generate [{::grammar/keys [module instance] :as grammar}]
-  (-> (service/compile-request module instance {(str module)                (->abstract grammar)
-                                                (str module "Body")         (->incomplete grammar)
-                                                (str module "Lex")          (->interface grammar)
-                                                (str module "Lex" instance) (->resource grammar)
-                                                (str module instance)       (->concrete grammar)})
-      (get :body)
-      (json/read-value utils/read-mapper)
-      (get-in [:results 0 1])
-      (sort)
-      (dedupe)))
+  (let [{body :body} (service/compile-request module instance (grammar->content grammar))
+        {[[_ results]] :results error :error} (json/read-value body utils/read-mapper)]
+    (if (some? error)
+      (log/error error)
+      (sort (dedupe results)))))
 
 (s/fdef generate
         :args (s/cat :grammar :acc-text.nlg.gf.grammar/grammar)
-        :ret (s/coll-of string?))
+        :ret (s/nilable (s/coll-of string?)))


### PR DESCRIPTION
If GF produces error, it is returned in response, eg:

```
{"error": "\n/tmp/tmpxNe2vH/test.gf:1:0: syntax error\n"}
```