### PR TITLE
172049880 simplify generate api

### DIFF
--- a/api/src/api/server.clj
+++ b/api/src/api/server.clj
@@ -54,7 +54,6 @@
                              :summary "GraphQL endpoint"}
                    :options cors-handler}]
      ["/nlg/" {:post    {:parameters {:body ::generate/generate-req}
-                         :responses  {200 {:body {:resultId string?}}}
                          :summary    "Registers document plan for generation"
                          :coercion   reitit.coercion.spec/coercion
                          :middleware [muuntaja/format-request-middleware


### PR DESCRIPTION
Changes:
- Allow to give `dataRow` (represents single CSV row, pass as a dictionary) instead of `dataId`
- Allow to specify `async: false` (default is `true`, to keep current behaviour) which will return full result, instead of `resultId`

Example request:

```
curl -X POST -H "Content-Type: application/json" http://localhost:3001/nlg/ -d '{"documentPlanName": "Restaurants", "dataRow": {"name": "Test", "area": "city center"}, "readerFlagValues": {"English": true}, "async": false}'
```

Gives output:

```
[{"lang":"Eng","original":"Test is a the adult establishment place. Test is in the city center."},
{"lang":"Eng","original":"Test is a the adult establishment place. Test located in the city center."},
{"lang":"Eng","original":"Test is an an adult establish place. Test is in the city center."},
{"lang":"Eng","original":"Test is an an adult establish place. Test located in the city center."},
{"lang":"Eng","original":"Test is in the city center. Test is a the adult establishment place."},
{"lang":"Eng","original":"Test is in the city center. Test is an an adult establish place."},
{"lang":"Eng","original":"Test is in the city center. Test isn't a family friendly place."},
{"lang":"Eng","original":"Test isn't a family friendly place. Test is in the city center."},
{"lang":"Eng","original":"Test isn't a family friendly place. Test located in the city center."},
{"lang":"Eng","original":"Test located in the city center. Test is a the adult establishment place."},
{"lang":"Eng","original":"Test located in the city center. Test is an an adult establish place."},
{"lang":"Eng","original":"Test located in the city center. Test isn't a family friendly place."}]
```