### PR TITLE
172046933 fix refexpr

### DIFF
--- a/api/src/api/nlg/generate.clj
+++ b/api/src/api/nlg/generate.clj
@@ -1,6 +1,6 @@
 (ns api.nlg.generate
   (:require [acc-text.nlg.core :as nlg]
-            #_[acc-text.nlp.ref-expressions :refer [apply-ref-expressions]]
+            [acc-text.nlp.ref-expressions :refer [apply-ref-expressions]]
             [api.nlg.context :as context]
             [api.nlg.enrich :refer [enrich-texts]]
             [api.nlg.parser :as parser]

--- a/api/src/api/nlg/generate.clj
+++ b/api/src/api/nlg/generate.clj
@@ -42,7 +42,7 @@
                         :original %}
                        (true? enrich) (assoc :enriched (sort (set/difference
                                                                (set (enrich-texts % (:data context))) %))))
-              #_#(apply-ref-expressions lang %)))))
+              #(apply-ref-expressions lang %)))))
 
 (defn reader-model->languages [reader-model]
   (reduce-kv (fn [acc k v]

--- a/core/src/acc_text/nlp/ref_expressions.clj
+++ b/core/src/acc_text/nlp/ref_expressions.clj
@@ -11,7 +11,6 @@
       (reverse final)
       (let [[head & tail] pairs
             [[p1 v1] [p2 v2]] head]
-        (println v1)
         (if (= 1 (- p2 p1))
           (recur (rest tail) (cons [p1 (clojure.string/join " " [v1 v2])] final))
           (recur tail (cons [p1 v1] final)))

--- a/core/src/acc_text/nlp/ref_expressions.clj
+++ b/core/src/acc_text/nlp/ref_expressions.clj
@@ -8,7 +8,7 @@
 
 (defmethod ignored-token? :default [_ _] false)
 
-(defn filter-ignored-tokens [lang [value _]] (ignored-token? lang value))
+(defn remove-ignored-tokens [lang [value _]] (ignored-token? lang value))
 
 (defn filter-by-refs-count [[_ refs]] (>= (count refs) 2))
 
@@ -21,8 +21,7 @@
             [[p1 v1] [p2 v2]] head]
         (if (= 1 (- p2 p1))
           (recur (rest tail) (cons [p1 (clojure.string/join " " (log/spyf "Merging: %s" [v1 v2]))] final))
-          (recur tail (cons [p1 v1] final)))
-        ))))
+          (recur tail (cons [p1 v1] final)))))))
 
 
 (defn filter-last-location-token
@@ -42,7 +41,7 @@
        (filter #(referent? (second %)))
        (merge-nearby)
        (group-by second)
-       (filter #(filter-ignored-tokens lang %))
+       (remove #(remove-ignored-tokens lang %))
        (filter filter-by-refs-count)
        (map (comp rest second))
        (mapcat (partial filter-last-location-token tokens))))

--- a/core/src/acc_text/nlp/ref_expressions.clj
+++ b/core/src/acc_text/nlp/ref_expressions.clj
@@ -4,6 +4,20 @@
 
 (defn filter-by-refs-count [[_ refs]] (>= (count refs) 2))
 
+(defn merge-nearby [tokens]
+  (loop [pairs (partition 2 1 tokens)
+         final ()]
+    (if (empty? pairs)
+      (reverse final)
+      (let [[head & tail] pairs
+            [[p1 v1] [p2 v2]] head]
+        (println v1)
+        (if (= 1 (- p2 p1))
+          (recur (rest tail) (cons [p1 (clojure.string/join " " [v1 v2])] final))
+          (recur tail (cons [p1 v1] final)))
+        ))))
+
+
 (defn filter-last-location-token
   [all-tokens group]
   (filter (fn [[idx token]]
@@ -19,10 +33,15 @@
   [tokens]
   (->> (map-indexed vector tokens)
        (filter #(referent? (second %)))
+       (merge-nearby)
        (group-by second)
        (filter filter-by-refs-count)
        (map (comp rest second))
        (mapcat (partial filter-last-location-token tokens))))
+
+(defmulti ignored-tokens (fn [lang _] lang))
+
+(defmethod ignored-tokens "Eng" [_ [idx value]])
 
 (defmulti add-replace-token (fn [lang _] lang))
 

--- a/core/src/acc_text/nlp/ref_expressions.clj
+++ b/core/src/acc_text/nlp/ref_expressions.clj
@@ -19,9 +19,9 @@
       (reverse final)
       (let [[head & tail] pairs
             [[p1 v1] [p2 v2]] head]
-        (if (= 1 (- p2 p1))
+        (if (= 1 (- p2 p1))  ;; If distance between words is one token - merge them
           (recur (rest tail) (concat [[p2 ""] [p1 (clojure.string/join " " (log/spyf :debug "Merging: %s" [v1 v2]))]] final))
-          (recur tail (cons [p1 v1] final)))))))
+          (recur tail (cons [p1 v1] final))))))) ;; Otherwise, put first one into the list and continue forward
 
 
 (defn filter-last-location-token

--- a/core/src/acc_text/nlp/ref_expressions.clj
+++ b/core/src/acc_text/nlp/ref_expressions.clj
@@ -20,7 +20,7 @@
       (let [[head & tail] pairs
             [[p1 v1] [p2 v2]] head]
         (if (= 1 (- p2 p1))
-          (recur (rest tail) (cons [p1 (clojure.string/join " " (log/spyf "Merging: %s" [v1 v2]))] final))
+          (recur (rest tail) (concat [[p2 ""] [p1 (clojure.string/join " " (log/spyf :debug "Merging: %s" [v1 v2]))]] final))
           (recur tail (cons [p1 v1] final)))))))
 
 
@@ -79,6 +79,7 @@
                   (map (partial add-replace-token lang))
                   (check-for-dupes)
                   (into {}))]
+    (log/debugf "Smap: %s" smap)
     (nlp/rebuild-sentences
       (map-indexed (fn [idx v]
                      (cond (= :delete (get smap idx)) ""

--- a/core/src/acc_text/nlp/ref_expressions.clj
+++ b/core/src/acc_text/nlp/ref_expressions.clj
@@ -1,6 +1,7 @@
 (ns acc-text.nlp.ref-expressions
   (:require [acc-text.nlp.utils :as nlp]
-            [clojure.tools.logging :as log]))
+            [clojure.tools.logging :as log]
+            [clojure.string :as str]))
 
 (defmulti ignored-token? (fn [lang _] lang))
 
@@ -20,7 +21,7 @@
       (let [[head & tail] pairs
             [[p1 v1] [p2 v2]] head]
         (if (= 1 (- p2 p1))  ;; If distance between words is one token - merge them
-          (recur (rest tail) (concat [[p2 ""] [p1 (clojure.string/join " " (log/spyf :debug "Merging: %s" [v1 v2]))]] final))
+          (recur (rest tail) (concat [[p2 ""] [p1 (str/join " " (log/spyf :debug "Merging: %s" [v1 v2]))]] final))
           (recur tail (cons [p1 v1] final))))))) ;; Otherwise, put first one into the list and continue forward
 
 

--- a/core/test/acc_text/nlp/ref_expressions_test.clj
+++ b/core/test/acc_text/nlp/ref_expressions_test.clj
@@ -24,3 +24,7 @@
 (deftest test-test-test-case
   (is (= "TEST TEST TEST."
          (r/apply-ref-expressions "Eng" "TEST TEST TEST"))))
+
+(deftest I-case
+  (is (= "I was doing something. Later I was doing something else."
+         (r/apply-ref-expressions "Eng" "I was doing something. Later I was doing something else."))))

--- a/core/test/acc_text/nlp/ref_expressions_test.clj
+++ b/core/test/acc_text/nlp/ref_expressions_test.clj
@@ -5,9 +5,9 @@
 
 (deftest test-identify-refs
   (is (= [4 "Alimentum"]
-         (-> (nlp/tokenize "Alimentum is nice. Alimentum serves good food. We will eat at Alimentum.")
-             (r/identify-potential-refs)
-             (first)))))
+         (->> (nlp/tokenize "Alimentum is nice. Alimentum serves good food. We will eat at Alimentum.")
+              (r/identify-potential-refs "Eng")
+              (first)))))
 
 (deftest test-replace-refs
   (is (= "Alimentum is nice. It serves good food. Starbucks provides coffee. Its coffee is awesome. We're going to drink coffee at Starbucks."

--- a/core/test/acc_text/nlp/ref_expressions_test.clj
+++ b/core/test/acc_text/nlp/ref_expressions_test.clj
@@ -22,5 +22,5 @@
          (r/apply-ref-expressions "Eng" "The T1000 is shiny. The T1000 makes noise."))))
 
 (deftest test-test-test-case
-  (is (= "TEST TEST TEST"
+  (is (= "TEST TEST TEST."
          (r/apply-ref-expressions "Eng" "TEST TEST TEST"))))

--- a/core/test/acc_text/nlp/ref_expressions_test.clj
+++ b/core/test/acc_text/nlp/ref_expressions_test.clj
@@ -20,3 +20,7 @@
 (deftest the-it-case
   (is (= "The T1000 is shiny. It makes noise."
          (r/apply-ref-expressions "Eng" "The T1000 is shiny. The T1000 makes noise."))))
+
+(deftest test-test-test-case
+  (is (= "TEST TEST TEST"
+         (r/apply-ref-expressions "Eng" "TEST TEST TEST"))))


### PR DESCRIPTION
- Merge potential tokens which are nearby, eg. "Macbook PRO" would be made into a single token. It will be replaced to `it` only if there's another fulll mention.

- Ignore list for languages. Some tokens needs to be ignored, eg. "I" in english.