### PR TITLE
Datomic persistence

### DIFF
--- a/api/src/api/config.clj
+++ b/api/src/api/config.clj
@@ -5,6 +5,7 @@
   {:port              (Integer/valueOf ^String (or (System/getenv "ACC_TEXT_API_PORT") "3001"))
    :host              (or (System/getenv "ACC_TEXT_API_HOST") "0.0.0.0")
    :db-implementation (when-let [db-implementation (or (System/getenv "DB_IMPLEMENTATION") "datomic")]
-                        (keyword db-implementation))})
+                        (keyword db-implementation))
+   :db-uri            (System/getenv "DB_URI")})
 
 (defstate conf :start (load-config))

--- a/api/src/data/datomic/utils.clj
+++ b/api/src/data/datomic/utils.clj
@@ -16,12 +16,15 @@
     (log/infof "Applying Datomic migration: %s" file-name)
     (c/ensure-conforms conn (c/read-resource (str schema-folder-name "/" file-name)))))
 
+(defn init-db [uri]
+  (d/create-database uri)
+  uri)
+
 (defn get-conn [conf]
   (let [c (d/connect (if-let [uri (:db-uri conf)]
-                       uri
+                       (init-db uri)
                        (let [uri (str "datomic:mem://" (str (UUID/randomUUID)))]
-                         (d/create-database uri)
-                         uri)))]
+                         (init-db uri))))]
     (migrate c)
     c))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
     ports: ["8002:8000"]
   datomic-transactor:
     image: "gordonstratton/datomic-free-transactor:latest"
-    ports: ["4334-4336:4334-4336"]
     networks:
       - datomic
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ version: '3.4'
 
 services:
   acc-text-api:
+    networks:
+      - default
+      - datomic
     build:
       context: .
       dockerfile: api/Dockerfile
@@ -11,6 +14,7 @@ services:
       ENABLE_ENRICH: "TRUE"
       ENRICH_ENDPOINT: "http://enrich:8000"
       DB_IMPLEMENTATION: "datomic"
+      DB_URI: "datomic:free://datomic-transactor:4334/acc-text?password=datomic"
       GRAMMAR_SYNTAX: "/opt/syntax"
       GRAMMAR_PARADIGMS: "/opt/paradigms"
       DATA_FILES: "/opt/data-files"
@@ -18,6 +22,9 @@ services:
       DOCUMENT_PLANS: "/opt/document-plans"
     volumes:
       - ./api/resources:/opt
+    depends_on:
+      - datomic-transactor
+      - gf
   gf:
     build:
       context: ./core/gf
@@ -26,8 +33,17 @@ services:
     build:
       context: ./enrich
     ports: ["8002:8000"]
-  transactor:
+  datomic-transactor:
     image: "gordonstratton/datomic-free-transactor:latest"
     ports: ["4334-4336:4334-4336"]
+    networks:
+      - datomic
+    environment:
+      DATOMIC_HOST: "datomic-transactor"
+      DATOMIC_ALT_HOST: "acc-text-api"
     volumes:
       - ./api/data:/srv/datomic/data
+
+networks:
+  default:
+  datomic:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,3 +26,8 @@ services:
     build:
       context: ./enrich
     ports: ["8002:8000"]
+  transactor:
+    image: "gordonstratton/datomic-free-transactor:latest"
+    ports: ["4334-4336:4334-4336"]
+    volumes:
+      - ./api/data:/srv/datomic/data


### PR DESCRIPTION
Setup and use datomic transactor. This allows to persist datomic state.

Things to do:
- Have a separate database init script. Now it is initializing everytime API is started: creating database, uploading RGLs, AMRs, DocumentPlans...
- Setup an option to run without transactor, because it takes additional time
- Connection between Transactor and Acc-Text API is a bit too verbose
