### PR TITLE
Don't use debian `python-pip`

### DIFF
--- a/core/gf/Dockerfile
+++ b/core/gf/Dockerfile
@@ -1,6 +1,8 @@
 FROM haskell:8.8.3
 
-RUN apt-get update && apt-get install wget python python-pip -y
+RUN apt-get update && apt-get install wget python libtinfo5 -y
+
+RUN curl https://bootstrap.pypa.io/get-pip.py | python
 
 RUN pip install backports.tempfile gunicorn pytest
 

--- a/core/gf/gf.py
+++ b/core/gf/gf.py
@@ -2,7 +2,10 @@ import six
 import logging
 import subprocess
 
-from backports.tempfile import TemporaryDirectory
+try:
+    from tempfile import TemporaryDirectory
+except ImportError:
+    from backports.tempfile import TemporaryDirectory
 
 
 logger = logging.getLogger("gf")


### PR DESCRIPTION
debian pip writes into `dist-packages`while normal python is searching in `site-packages`. This is Ubuntu/Debian stuff, I guess for system components to don't break. However this messes things up, so use original pip