### PR TITLE
Add export to utils

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,0 +1,2 @@
+generate-from-csv:
+	clojure -A:test -e:integration

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,2 +1,2 @@
 generate-from-csv:
-	clojure -A:test -e:integration
+	clojure -m utils.generate $(doc-plan) "$(data-file)" "$(output-file)"

--- a/utils/deps.edn
+++ b/utils/deps.edn
@@ -1,8 +1,9 @@
-{:deps      {core                             {:local/root "../core"}
-             api                              {:local/root "../api"}
-             http-kit                         {:mvn/version "2.3.0"}
-             org.clojure/clojure              {:mvn/version "1.10.1"}
-             floatingpointio/graphql-builder  {:mvn/version "0.1.10"}}
+{:deps      {core                            {:local/root "../core"}
+             api                             {:local/root "../api"}
+             http-kit                        {:mvn/version "2.3.0"}
+             org.clojure/data.csv            {:mvn/version "1.0.0"}
+             org.clojure/clojure             {:mvn/version "1.10.1"}
+             floatingpointio/graphql-builder {:mvn/version "0.1.10"}}
  :paths     ["src" "resources"]
  :mvn/repos {"central" {:url "https://repo1.maven.org/maven2/"}
              "clojars" {:url "https://repo.clojars.org/"}}}

--- a/utils/src/utils/generate.clj
+++ b/utils/src/utils/generate.clj
@@ -62,7 +62,13 @@
                              csv-data))))))
 
 (defn data->text [document-plan data-file output-file]
+  (log/infof "Generating using '%s' document plan" document-plan)
   (->> data-file
        (read-data)
        (generate-bulk document-plan)
        (save-data-with-variants output-file)))
+
+(defn -main [& [document-plan data-file output-file]]
+  (if (and document-plan data-file output-file)
+    (data->text document-plan data-file output-file)
+    (println "Usage: pass in three parameters: name of the document plan, path to a data file, and path to an output file")))

--- a/utils/src/utils/generate.clj
+++ b/utils/src/utils/generate.clj
@@ -1,0 +1,39 @@
+(ns utils.generate
+  (:require [clojure.data.csv :as csv]
+            [clojure.java.io :as io]))
+
+(defn read-data [csv-file]
+  (with-open [reader (io/reader csv-file)]
+    (let [csv-data (doall (csv/read-csv reader))]
+      (map zipmap
+           (repeat (first csv-data))
+           (rest csv-data)))))
+
+(def colog [{"Department Brand" "Acqua di Parma" "Division" "toiletries" "Subclass" "shaving cream" "Color (UDA)" "" "Gender" "man" "Class" "cologne"}])
+
+(defn write-variants-to-file [variants id-column output-dir]
+  (prn "Writing: " (get variants id-column))
+  (-> output-dir (io/file) .mkDirs)
+  (doseq [line variants]
+    (spit (format "%s/%s.txt" output-dir (get variants id-column))
+          (str line "\n")
+          :append true)))
+
+(defn generate-bulk [document-plan-name data]
+  (let [ids (take (count data) (repeatedly #(str (java.util.UUID/randomUUID))))]
+    (api.nlg.service/generate-request-bulk
+     {:documentPlanName document-plan-name
+      :dataRows         (zipmap ids data)
+      :readerFlagValues {"English" true}})
+    (map (fn [id data-row]
+           (let [{{variants :variants} :body} (api.nlg.service/get-result
+                                               {:parameters {:path  {:id (str id)}
+                                                             :query {:format "raw"}}})]
+             (assoc data-row "results" (clojure.string/join "\n\n" variants))))
+         ids data)))
+
+(defn save-results-to-dir [data-file output-dir document-plan id-column]
+  (->> data-file
+      (read-data)
+      (generate-bulk document-plan)
+      (write-variants-to-file id-column output-dir)))

--- a/utils/src/utils/generate.clj
+++ b/utils/src/utils/generate.clj
@@ -1,6 +1,12 @@
 (ns utils.generate
   (:require [clojure.data.csv :as csv]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [org.httpkit.client :as http]
+            [jsonista.core :as json]
+            [clojure.tools.logging :as log]
+            [clojure.string :as string]))
+
+(def read-mapper (json/object-mapper {:decode-key-fn true}))
 
 (defn read-data [csv-file]
   (with-open [reader (io/reader csv-file)]
@@ -9,31 +15,50 @@
            (repeat (first csv-data))
            (rest csv-data)))))
 
-(def colog [{"Department Brand" "Acqua di Parma" "Division" "toiletries" "Subclass" "shaving cream" "Color (UDA)" "" "Gender" "man" "Class" "cologne"}])
+(defn- post-generate [body]
+  (-> @(http/post "http://localhost:3001/nlg/_bulk/"
+                  {:headers {"Content-Type" "application/json"}
+                   :body    (json/write-value-as-string body)})
+      :body (json/read-value read-mapper) :resultIds))
 
-(defn write-variants-to-file [variants id-column output-dir]
-  (prn "Writing: " (get variants id-column))
-  (-> output-dir (io/file) .mkDirs)
-  (doseq [line variants]
-    (spit (format "%s/%s.txt" output-dir (get variants id-column))
-          (str line "\n")
-          :append true)))
+(defn- get-results [id]
+  [id (-> (format "http://localhost:3001/nlg/%s?format=raw" id)
+          http/get deref
+          :body (json/read-value read-mapper)
+          :variants)])
 
-(defn generate-bulk [document-plan-name data]
-  (let [ids (take (count data) (repeatedly #(str (java.util.UUID/randomUUID))))]
-    (api.nlg.service/generate-request-bulk
-     {:documentPlanName document-plan-name
-      :dataRows         (zipmap ids data)
-      :readerFlagValues {"English" true}})
-    (map (fn [id data-row]
-           (let [{{variants :variants} :body} (api.nlg.service/get-result
-                                               {:parameters {:path  {:id (str id)}
-                                                             :query {:format "raw"}}})]
-             (assoc data-row "results" (clojure.string/join "\n\n" variants))))
-         ids data)))
+(defn generate-bulk
+  "Generate text variants for data rows. Return collection of tuples where
+  first entry is original data and the second is a collection of variants."
+  [document-plan data]
+  (let [ids      (take (count data) (repeatedly #(str (java.util.UUID/randomUUID))))
+        id->data (zipmap ids data)]
+    (->> {:documentPlanName document-plan
+          :dataRows         id->data
+          :readerFlagValues {"English" true}}
+         (post-generate)
+         (map get-results)
+         (map (fn [[id variants]]
+                [(get id->data id) variants])))))
 
-(defn save-results-to-dir [data-file output-dir document-plan id-column]
+(defn save-data-with-variants
+  "Merge data rows and text variantas. For each text variant for the data item
+  create a new row with all the data points duplicated"
+  [out-file results]
+  (let [header (vec (map name (-> results first first keys)))
+        csv-data (mapcat (fn [[data variations]]
+                        (let [data-row (vec (map (fn [col] (get data col)) header))]
+                          (map (fn [variant]
+                                 (conj data-row variant))
+                               variations)))
+                      results)]
+    (with-open [writer (io/writer out-file)]
+      (csv/write-csv writer
+                     (cons (conj (vec (map name (-> results first first keys))) "Variants")
+                           csv-data)))))
+
+(defn data->text [document-plan data-file output-file]
   (->> data-file
-      (read-data)
-      (generate-bulk document-plan)
-      (write-variants-to-file id-column output-dir)))
+       (read-data)
+       (generate-bulk document-plan)
+       (save-data-with-variants output-file)))

--- a/utils/src/utils/queries.clj
+++ b/utils/src/utils/queries.clj
@@ -1,7 +1,6 @@
 (ns utils.queries
   (:require [graphql-builder.parser :refer [parse read-file]]
             [graphql-builder.core :as core]
-            [jsonista.core :as json]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [data.utils :refer [list-files]]))


### PR DESCRIPTION
Add utility which can read CSV file, invoke text generation for each data point, and save the results.

Example invocation via make command
```
make generate-from-csv \
  doc-plan=50products \
  data-file=datasets/products.csv \
  output-file=datasets/results.csv
```