### PR TITLE
Hardcode build args instead of nginx config

### DIFF
--- a/docker-compose.front-end.yml
+++ b/docker-compose.front-end.yml
@@ -4,7 +4,3 @@ services:
   front-end:
     image: acctext/frontend:latest
     ports: ["8080:80"]
-    depends_on:
-      - acc-text-api
-    volumes:
-      - ./front-end/nginx.local.conf:/etc/nginx/nginx.conf

--- a/front-end/Makefile
+++ b/front-end/Makefile
@@ -39,5 +39,5 @@ copy-resources:
 compile-frontend-services: prepare-builder copy-resources
 
 publish-frontend-docker:
-	docker build -t ${FRONTEND_IMAGE} --build-arg ACC_TEXT_DATA_FILES_BUCKET="/accelerated-text-data-files/" -f Dockerfile.builder ../
+	docker build -t ${FRONTEND_IMAGE} --build-arg ACC_TEXT_API_URL="http://localhost:3001" --build-arg ACC_TEXT_GRAPHQL_URL="http://localhost:3001/_graphql" --build-arg ACC_TEXT_DATA_FILES_BUCKET="http://localhost:3001/accelerated-text-data-files/" -f Dockerfile.builder ../
 	docker push ${FRONTEND_IMAGE}


### PR DESCRIPTION
Don't use inner NGINX, hardcode concrete endpoints now