### PR TITLE
Mention SHOW_FLAGS environment variable

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,6 +61,7 @@ DATA_FILES: "/opt/data-files"
 DICT_PATH: "/opt/dictionary"
 DOCUMENT_PLANS: "/opt/document-plans"
 ENABLED_LANGUAGES: "eng"
+SHOW_FLAGS: "true"
 ```
 
 ### Front-End


### PR DESCRIPTION
SHOW_FLAGS is `true` by default and the API will return a country flag for the selected reader model language. Making this `false` will remove that prefix.