### PR TITLE
Extend dictionary item schema

### DIFF
--- a/api/deps.edn
+++ b/api/deps.edn
@@ -1,6 +1,6 @@
 {:deps      {accelerated-text/core                {:local/root "../core"}
              ch.qos.logback/logback-classic       {:mvn/version "1.2.3"}
-             com.walmartlabs/lacinia              {:mvn/version "0.35.0"}
+             com.walmartlabs/lacinia              {:mvn/version "0.38.0"}
              http-kit/http-kit                    {:mvn/version "2.3.0"}
              javax.servlet/servlet-api            {:mvn/version "2.5"}
              ring/ring-core                       {:mvn/version "1.7.1"}

--- a/api/resources/schema.graphql
+++ b/api/resources/schema.graphql
@@ -22,36 +22,36 @@ enum Language {
 }
 
 enum PartOfSpeech {
-   A
-   A2
-   AdA
-   AdN
-   AdV
-   Adv
-   Conj
-   IP
-   Interj
-   N
-   N2
-   N3
-   NP
-   PN
-   Post
-   Prep
-   Pron
-   Quant
-   Subj
-   V
-   V2
-   V2A
-   V2S
-   V2V
-   V2Q
-   V3
-   VA
-   VQ
-   VS
-   VV
+    A
+    A2
+    AdA
+    AdN
+    AdV
+    Adv
+    Conj
+    IP
+    Interj
+    N
+    N2
+    N3
+    NP
+    PN
+    Post
+    Prep
+    Pron
+    Quant
+    Subj
+    V
+    V2
+    V2A
+    V2S
+    V2V
+    V2Q
+    V3
+    VA
+    VQ
+    VS
+    VV
 }
 
 ### Data -----------------------------------------------------------------------
@@ -238,6 +238,7 @@ type DocumentPlan {
     dataSampleId:      ID
     dataSampleRow:     Int
     dataSampleMethod:  String
+    examples:          [ String ]
     createdAt:         Int!
     updatedAt:         Int
     updateCount:       Int!
@@ -384,7 +385,7 @@ type Mutation {
         attributes:         [ Attribute ]
     ):  DictionaryItem!
 
-deleteDictionaryItem(
+    deleteDictionaryItem(
         id:                 ID!
     ): Boolean!
 
@@ -407,6 +408,7 @@ deleteDictionaryItem(
         dataSampleId:       ID
         dataSampleRow:      Int
         dataSampleMethod:   String
+        examples:           [ String ]
     ): DocumentPlan!
 
     deleteDocumentPlan(
@@ -423,6 +425,7 @@ deleteDictionaryItem(
         dataSampleId:       ID
         dataSampleRow:      Int
         dataSampleMethod:   String
+        examples:           [ String ]
     ): DocumentPlan!
 
     createPhrase(

--- a/api/resources/schema.graphql
+++ b/api/resources/schema.graphql
@@ -11,27 +11,44 @@ enum Usage {
     DONT_CARE
 }
 
-#   Taken from: https://www.clips.uantwerpen.be/pages/mbsp-tags
+enum Language {
+    Eng
+    Ger
+    Est
+    Lit
+    Lav
+    Rus
+    Spa
+}
+
 enum PartOfSpeech {
    A
    A2
-   compoundA
+   AdA
+   AdN
+   AdV
    Adv
+   Conj
+   IP
+   Interj
    N
    N2
    N3
+   NP
    PN
+   Post
    Prep
+   Pron
+   Quant
+   Subj
    V
-   V0
    V2
-   V3
    V2A
-   V2Q
    V2S
    V2V
+   V2Q
+   V3
    VA
-   VP
    VQ
    VS
    VV
@@ -143,12 +160,22 @@ type DictionaryResults {
     totalCount:         Int!
 }
 
+type DictionaryItemAttribute {
+    id:                 ID!
+    name:               String!
+    value:              String!
+}
+
 type DictionaryItem {
     id:                 ID!
     name:               String!
     partOfSpeech:       PartOfSpeech
     phrases:            [ Phrase! ]
     concept:            Concept
+    language:           Language
+    sense:              String
+    definition:         String
+    attributes:         [ DictionaryItemAttribute ]
 }
 
 type Phrase {
@@ -324,6 +351,12 @@ type Query {
 
 ### Mutations ------------------------------------------------------------------
 
+input Attribute {
+    id:                     ID
+    name:                   String!
+    value:                  String!
+}
+
 type Mutation {
 
     ### Dictionary
@@ -331,16 +364,27 @@ type Mutation {
     createDictionaryItem(
         id:                 ID
         name:               String!
-        partOfSpeech:       PartOfSpeech  # default = VB
+        partOfSpeech:       PartOfSpeech  # default = V
+        key:                String
+        forms:              [ String ]
+        language:           Language
+        sense:              String
+        definition:         String
+        attributes:         [ Attribute ]
     ):  DictionaryItem!
 
     updateDictionaryItem(
         id:                 ID!
         name:               String
         partOfSpeech:       PartOfSpeech
+        key:                String
+        language:           Language
+        sense:              String
+        definition:         String
+        attributes:         [ Attribute ]
     ):  DictionaryItem!
 
-    deleteDictionaryItem(
+deleteDictionaryItem(
         id:                 ID!
     ): Boolean!
 

--- a/api/src/api/graphql/translate/concept.clj
+++ b/api/src/api/graphql/translate/concept.clj
@@ -34,7 +34,7 @@
     (->> roles
          (group-by :name)
          (vals)
-         (map (comp #(assoc % :category (get role-category (:name %) (:category %))) first))
+         (map (comp #(assoc % :category (or (get role-category (:name %)) "Str")) first))
          (sort-by (comp role-position :name)))))
 
 (defn amr->schema [{::sg/keys [id category description name] :as entity}]

--- a/api/src/api/graphql/translate/concept.clj
+++ b/api/src/api/graphql/translate/concept.clj
@@ -24,7 +24,7 @@
 
 (defn find-categories [roles]
   (reduce-kv (fn [m k v]
-               (assoc m k (paths/get-intersection (map :category v))))
+               (assoc m k (paths/get-intersection (map (comp #(str/replace % #"[()]" "") :category) v))))
              {}
              (group-by :name roles)))
 

--- a/api/src/api/graphql/translate/document_plan.clj
+++ b/api/src/api/graphql/translate/document_plan.clj
@@ -1,5 +1,6 @@
 (ns api.graphql.translate.document-plan
   (:require [api.utils :refer [read-mapper]]
+            [clojure.string :as str]
             [jsonista.core :as json]))
 
 (defn schema->dp [{:keys [id uid name kind examples blocklyXml documentPlan dataSampleId dataSampleRow dataSampleMethod]}]
@@ -7,7 +8,7 @@
    :uid              uid
    :name             name
    :kind             kind
-   :examples         examples
+   :examples         (remove str/blank? examples)
    :blocklyXml       blocklyXml
    :documentPlan     (json/read-value documentPlan read-mapper)
    :dataSampleId     dataSampleId

--- a/api/src/api/graphql/translate/document_plan.clj
+++ b/api/src/api/graphql/translate/document_plan.clj
@@ -2,11 +2,12 @@
   (:require [api.utils :refer [read-mapper]]
             [jsonista.core :as json]))
 
-(defn schema->dp [{:keys [id uid name kind blocklyXml documentPlan dataSampleId dataSampleRow dataSampleMethod]}]
+(defn schema->dp [{:keys [id uid name kind examples blocklyXml documentPlan dataSampleId dataSampleRow dataSampleMethod]}]
   {:id               id
    :uid              uid
    :name             name
    :kind             kind
+   :examples         examples
    :blocklyXml       blocklyXml
    :documentPlan     (json/read-value documentPlan read-mapper)
    :dataSampleId     dataSampleId

--- a/api/src/api/nlg/parser.clj
+++ b/api/src/api/nlg/parser.clj
@@ -394,7 +394,7 @@
 
 (defn select-kind [kinds]
   (cond
-    (= 1 (count kinds)) (first kinds)))
+    (= 1 (count (set kinds))) (first kinds)))
 
 (defn post-add-kind [{:keys [name type kind] :as node} {variables :variables}]
   (let [kinds (map :kind (remove definition? (dp-zip/get-children node)))

--- a/api/src/data/entities/document_plan/utils.clj
+++ b/api/src/data/entities/document_plan/utils.clj
@@ -2,7 +2,8 @@
   (:require [data.entities.document-plan.zip :as dp-zip]
             [clojure.zip :as zip]
             [clojure.java.io :as io]
-            [clojure.data.xml :as xml]))
+            [clojure.data.xml :as xml]
+            [clojure.string :as str]))
 
 (defn get-variable-labels [blockly-xml]
   (when (some? blockly-xml)
@@ -29,9 +30,9 @@
     (or (->> (get-nodes-with-types body #{"Define-var"})
              (filter #(and (= "Define-var" (:type %)) (= "*Description" (get labels (:name %)))))
              (map (comp :text :value))
-             (remove nil?)
+             (remove str/blank?)
              (seq))
-        examples)))
+        (remove str/blank? examples))))
 
 (defn find-variables [{body :documentPlan} labels]
   (->> (get-nodes-with-types body #{"Define-var"})

--- a/api/src/data/entities/document_plan/utils.clj
+++ b/api/src/data/entities/document_plan/utils.clj
@@ -24,12 +24,14 @@
        (map zip/node)
        (filter #(contains? types (:type %)))))
 
-(defn find-examples [{body :documentPlan blockly-xml :blocklyXml}]
+(defn find-examples [{body :documentPlan examples :examples blockly-xml :blocklyXml}]
   (let [labels (get-variable-labels blockly-xml)]
-    (->> (get-nodes-with-types body #{"Define-var"})
-         (filter #(and (= "Define-var" (:type %)) (= "*Description" (get labels (:name %)))))
-         (map (comp :text :value))
-         (remove nil?))))
+    (or (->> (get-nodes-with-types body #{"Define-var"})
+             (filter #(and (= "Define-var" (:type %)) (= "*Description" (get labels (:name %)))))
+             (map (comp :text :value))
+             (remove nil?)
+             (seq))
+        examples)))
 
 (defn find-variables [{body :documentPlan} labels]
   (->> (get-nodes-with-types body #{"Define-var"})

--- a/api/test/api/graphql/dictionary_test.clj
+++ b/api/test/api/graphql/dictionary_test.clj
@@ -51,6 +51,27 @@
     (is (= "test_V" name))
     (is (= "V" partOfSpeech))))
 
+(deftest ^:integration create-complex-dict-item-test
+  (let [query "mutation CreateDictionaryItem($name: String!, $partOfSpeech: PartOfSpeech, $key: String, $forms: [String], $language: Language, $sense: String, $definition: String, $attributes: [Attribute]) { createDictionaryItem(name: $name, partOfSpeech: $partOfSpeech, key: $key, forms: $forms, language: $language, sense: $sense, definition: $definition, attributes: $attributes) { name partOfSpeech language sense definition phrases { id text } attributes { id name value } } } "
+        {{{{:keys [name partOfSpeech language sense definition phrases attributes]} :createDictionaryItem} :data errors :errors} :body}
+        (q "/_graphql" :post {:query query :variables {:name         "test"
+                                                       :partOfSpeech "N"
+                                                       :key          "test_key"
+                                                       :language     "Eng"
+                                                       :sense        "test"
+                                                       :definition   "test"
+                                                       :forms        ["test" "tests"]
+                                                       :attributes   [{:name  "Gender"
+                                                                       :value "nonhuman"}]}})]
+    (is (nil? errors))
+    (is (= "test_key" name))
+    (is (= "N" partOfSpeech))
+    (is (= language "Eng"))
+    (is (= sense "test"))
+    (is (= definition "test"))
+    (is (= ["test" "tests"] (map :text phrases)))
+    (is (= {"Gender" "nonhuman"} (into {} (map (fn [{:keys [name value]}] [name value]) attributes))))))
+
 (deftest ^:integration delete-dict-item-test
   (let [query "mutation DeleteDictionaryItem($id:ID!){deleteDictionaryItem(id:$id)}"
         {{{response :deleteDictionaryItem} :data errors :errors} :body}

--- a/core/src/acc_text/nlg/core.clj
+++ b/core/src/acc_text/nlg/core.clj
@@ -1,5 +1,6 @@
 (ns acc-text.nlg.core
-  (:require [acc-text.nlg.dictionary.item :as dictionary-item]
+  (:require [acc-text.nlg.dictionary.item :as dict-item]
+            [acc-text.nlg.dictionary.item.attr :as dict-item-attr]
             [acc-text.nlg.semantic-graph :as sg]
             [acc-text.nlg.gf.service :as gf-service]
             [acc-text.nlg.grammar :as grammar]
@@ -12,9 +13,14 @@
       (update :amr #(zipmap (map ::sg/id %) %))
       (assoc :constants {"*Language" lang
                          "*Reader"   (str/join "," (:readers context))})
-      (update :dictionary #(zipmap (map (fn [{::dictionary-item/keys [key category]}]
-                                          [key category])
-                                        %)
+      (update :dictionary #(reduce (fn [m {::dict-item/keys [key category] :as dict-item}]
+                                     (assoc m [key category]
+                                              (update dict-item ::dict-item/attributes
+                                                      (fn [attrs]
+                                                        (into {} (map (fn [{::dict-item-attr/keys [name value]}]
+                                                                        [name value])
+                                                                      attrs))))))
+                                   {}
                                    %))))
 
 (defn generate-text [semantic-graph context lang]

--- a/core/src/acc_text/nlg/gf/paths.clj
+++ b/core/src/acc_text/nlg/gf/paths.clj
@@ -1,6 +1,7 @@
 (ns acc-text.nlg.gf.paths
   (:require [acc-text.nlg.gf.utils :as utils]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.set :as set]))
 
 (defn load-paths [resource-path]
   (utils/read-edn (io/file (io/resource resource-path))))
@@ -20,3 +21,10 @@
        (reduce-kv (fn [m k v]
                     (assoc m k (set (map first v))))
                   {})))
+
+(defn get-intersection [categories]
+  (->> categories
+       (map #(set (conj (get possible-paths %) %)))
+       (apply set/intersection)
+       (some #(when (contains? (set categories) %)
+                %))))

--- a/core/src/acc_text/nlg/graph/categories.clj
+++ b/core/src/acc_text/nlg/graph/categories.clj
@@ -1,5 +1,6 @@
 (ns acc-text.nlg.graph.categories
-  (:require [acc-text.nlg.graph.utils :as utils]
+  (:require [acc-text.nlg.gf.paths :as paths]
+            [acc-text.nlg.graph.utils :as utils]
             [loom.alg :as alg]
             [loom.graph :as graph]))
 
@@ -21,6 +22,8 @@
               (case (count categories)
                 0 g
                 1 (set-category g node-id (first categories))
-                (throw (Exception. (format "Ambiguous categories for id `%s`" node-id))))))
+                (if-let [intersection (paths/get-intersection categories)]
+                  (set-category g node-id intersection)
+                  (throw (Exception. (format "Ambiguous categories for id `%s`" node-id)))))))
           g
           (alg/pre-traverse g (utils/find-root-id g))))


### PR DESCRIPTION
Additionally improved:
- AMR argument handling when categories are ambiguous (there will be no more errors when inside AMR the same argument has NP, CN and N categories, as well as others that are compatible)
- Document plan "about" text in UI can be added via graphql