### PR TITLE
Allow numbers in generate requests

### DIFF
--- a/api/src/api/nlg/service/request.clj
+++ b/api/src/api/nlg/service/request.clj
@@ -11,7 +11,7 @@
 
 (s/def ::format #{"raw" "annotated-text" "annotated-text-shallow"})
 
-(s/def ::dataRow (s/map-of string? string?))
+(s/def ::dataRow (s/map-of (s/or :s string? :n number?) (s/or :s string? :n number?)))
 
 (s/def ::dataRows (s/map-of ::id ::dataRow))
 


### PR DESCRIPTION
Previously, in generate requests, data like this would be unaccepted:
```
{1: 2, 3: 4}
```

Since spec enforsing strings:
```
{"1": "2", "3": "4"}
```